### PR TITLE
Install APCu stable version

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -26,7 +26,7 @@ script: |
   echo '\n' | pecl install imagick
 
   # apc
-  echo '\n' | pecl install apcu-beta
+  echo '\n' | pecl install apcu
 
   #memcache
   echo '\n' | pecl install memcache


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
